### PR TITLE
Update BANKS_URL.

### DIFF
--- a/lib/turkish_banks/turkish_bank.rb
+++ b/lib/turkish_banks/turkish_bank.rb
@@ -5,8 +5,8 @@ module TurkishBanks
     using TurkishSupport
     attr_accessor :last_update_date, :banks
 
-    BANKS_URL = "http://eft.tcmb.gov.tr/bankasubelistesi/bankaSubeTumListe.xml"    
-    
+    BANKS_URL = "http://eftemkt.tcmb.gov.tr/bankasubelistesi/bankaSubeTumListe.xml"
+
     def initialize
       doc = Nokogiri.XML(open(BANKS_URL), nil, 'UTF-8')
       doc.remove_namespaces!


### PR DESCRIPTION
TCMB changed the subdomain of the service from "eft" to "eftemkt".
